### PR TITLE
When play token gets lost, do only stop active audio playback.

### DIFF
--- a/resources/libs/spotimcgui/main.py
+++ b/resources/libs/spotimcgui/main.py
@@ -128,15 +128,14 @@ class SpotimcCallbacks(SessionCallbacks):
 
     @run_in_thread
     def play_token_lost(self, session):
-
-        #Cancel the current buffer
-        self.__audio_buffer.stop()
-
         if self.__app.has_var('playlist_manager'):
-            self.__app.get_var('playlist_manager').stop(False)
+            if self.__app.get_var('playlist_manager').is_playing():
+                #Cancel the current buffer
+                self.__audio_buffer.stop()
+                self.__app.get_var('playlist_manager').stop(False)
 
-        dlg = xbmcgui.Dialog()
-        dlg.ok('Playback stopped', 'This account is in use on another device.')
+                dlg = xbmcgui.Dialog()
+                dlg.ok('Playback stopped', 'This account is in use on another device.')
 
     def end_of_track(self, session):
         self.__audio_buffer.set_track_ended()

--- a/resources/libs/spotimcgui/playback.py
+++ b/resources/libs/spotimcgui/playback.py
@@ -216,6 +216,9 @@ class PlaylistManager:
             self.__playlist.add(path, info, index)
 
     def is_playing(self, consider_pause=True):
+        if not xbmc.getCondVisibility('Player.HasAudio()'):
+            return False
+
         if consider_pause:
             return xbmc.getCondVisibility('Player.Playing | Player.Paused')
         else:


### PR DESCRIPTION
 If spotimc is in the background, XBMC may play other stuff (TV, movie, ...) in the
moment the play token gets lost.

 BTW: I noticed, that spotimc does in no way take care of the fact that the xbmc music playlist may be populated with mixed content, from spotify and other sources. For instance, on exit spotify always clears the whole music playlist instaed of only removing the items spotimc added to that list.
